### PR TITLE
Added a orientation setting that allows the player to rotate the phase images.

### DIFF
--- a/src/main/java/com/zulrahhelper/ImageOrientation.java
+++ b/src/main/java/com/zulrahhelper/ImageOrientation.java
@@ -1,0 +1,25 @@
+package com.zulrahhelper;
+
+/**
+ * Orientation of the phase images in Cardinal directions
+ */
+public enum ImageOrientation {
+    SOUTH,
+    NORTH,
+    EAST,
+    WEST;
+
+    public double getRotation() {
+        switch (this) {
+            case NORTH:
+                return Math.PI;
+            case EAST:
+                return Math.PI / 2;
+            case WEST:
+                return Math.PI * 1.5f;
+            case SOUTH:
+            default:
+                return 0.0;
+        }
+    }
+}

--- a/src/main/java/com/zulrahhelper/ZulrahHelperConfig.java
+++ b/src/main/java/com/zulrahhelper/ZulrahHelperConfig.java
@@ -7,6 +7,14 @@ import net.runelite.client.config.Keybind;
 
 @ConfigGroup(ZulrahHelperPlugin.CONFIG_GROUP)
 public interface ZulrahHelperConfig extends Config {
+    enum ImageOrientation
+    {
+        DEFAULT,
+        RIGHT,
+        UPSIDE_DOWN,
+        LEFT
+    }
+
     @ConfigItem(
             keyName = ZulrahHelperPlugin.DARK_MODE_KEY,
             name = "Dark Mode",
@@ -65,5 +73,16 @@ public interface ZulrahHelperConfig extends Config {
     )
     default Keybind phaseSelection3Hotkey() {
         return Keybind.NOT_SET;
+    }
+
+    @ConfigItem(
+            keyName = "imageOrientation",
+            name = "Orientation",
+            description = "Rotate the phase images to the specified orientation.",
+            position = 7
+    )
+    default ImageOrientation imageOrientation()
+    {
+        return ImageOrientation.DEFAULT;
     }
 }

--- a/src/main/java/com/zulrahhelper/ZulrahHelperConfig.java
+++ b/src/main/java/com/zulrahhelper/ZulrahHelperConfig.java
@@ -7,14 +7,6 @@ import net.runelite.client.config.Keybind;
 
 @ConfigGroup(ZulrahHelperPlugin.CONFIG_GROUP)
 public interface ZulrahHelperConfig extends Config {
-    enum ImageOrientation
-    {
-        DEFAULT,
-        RIGHT,
-        UPSIDE_DOWN,
-        LEFT
-    }
-
     @ConfigItem(
             keyName = ZulrahHelperPlugin.DARK_MODE_KEY,
             name = "Dark Mode",
@@ -78,11 +70,11 @@ public interface ZulrahHelperConfig extends Config {
     @ConfigItem(
             keyName = "imageOrientation",
             name = "Orientation",
-            description = "Rotate the phase images to the specified orientation.",
+            description = "Rotate the phase images to the specified cardinal direction.",
             position = 7
     )
     default ImageOrientation imageOrientation()
     {
-        return ImageOrientation.DEFAULT;
+        return ImageOrientation.SOUTH;
     }
 }

--- a/src/main/java/com/zulrahhelper/ZulrahHelperPlugin.java
+++ b/src/main/java/com/zulrahhelper/ZulrahHelperPlugin.java
@@ -27,6 +27,7 @@ import java.util.List;
 public class ZulrahHelperPlugin extends Plugin {
     static final String CONFIG_GROUP = "zulrahhelper";
     static final String DARK_MODE_KEY = "darkMode";
+    static final String IMAGE_ORIENTATION_KEY = "imageOrientation";
 
     @Inject
     private KeyManager keyManager;
@@ -79,7 +80,7 @@ public class ZulrahHelperPlugin extends Plugin {
             return;
         }
 
-        if (event.getKey().equals(DARK_MODE_KEY)) {
+        if (event.getKey().equals(DARK_MODE_KEY) || event.getKey().equals(IMAGE_ORIENTATION_KEY)) {
             panel.update(state);
         }
     }

--- a/src/main/java/com/zulrahhelper/ui/ZulrahHelperPhasePanel.java
+++ b/src/main/java/com/zulrahhelper/ui/ZulrahHelperPhasePanel.java
@@ -1,6 +1,7 @@
 package com.zulrahhelper.ui;
 
 import com.zulrahhelper.Phase;
+import com.zulrahhelper.ZulrahHelperConfig;
 import com.zulrahhelper.ZulrahHelperPlugin;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.util.ImageUtil;
@@ -24,11 +25,6 @@ public class ZulrahHelperPhasePanel extends JPanel implements MouseListener {
         this.phase = phase;
 
         BufferedImage img = processImg(phase.getImage(plugin.getConfig()), rows);
-        final double theta = plugin.getConfig().imageOrientation().getRotation();
-        if (theta != 0) {
-            img = ImageUtil.rotateImage(img, theta);
-        }
-
         phaseIcon = new ImageIcon(img);
         phaseIconHover = new ImageIcon(ImageUtil.luminanceScale(img, .75f));
 
@@ -56,6 +52,12 @@ public class ZulrahHelperPhasePanel extends JPanel implements MouseListener {
         if (phase.isCompleted()) {
             img = ImageUtil.luminanceScale(img, 0.20f);
         }
+
+        final double theta = plugin.getConfig().imageOrientation().getRotation();
+        if (theta != 0) {
+            img = ImageUtil.rotateImage(img, theta);
+        }
+
         return img;
     }
 

--- a/src/main/java/com/zulrahhelper/ui/ZulrahHelperPhasePanel.java
+++ b/src/main/java/com/zulrahhelper/ui/ZulrahHelperPhasePanel.java
@@ -24,17 +24,9 @@ public class ZulrahHelperPhasePanel extends JPanel implements MouseListener {
         this.phase = phase;
 
         BufferedImage img = processImg(phase.getImage(plugin.getConfig()), rows);
-        switch (plugin.getConfig().imageOrientation())
-        {
-            case RIGHT:
-                img = ImageUtil.rotateImage(img, Math.PI / 2);
-                break;
-            case UPSIDE_DOWN:
-                img = ImageUtil.rotateImage(img, Math.PI);
-                break;
-            case LEFT:
-                img = ImageUtil.rotateImage(img, Math.PI * 1.5f);
-                break;
+        final double theta = plugin.getConfig().imageOrientation().getRotation();
+        if (theta != 0) {
+            img = ImageUtil.rotateImage(img, theta);
         }
 
         phaseIcon = new ImageIcon(img);

--- a/src/main/java/com/zulrahhelper/ui/ZulrahHelperPhasePanel.java
+++ b/src/main/java/com/zulrahhelper/ui/ZulrahHelperPhasePanel.java
@@ -24,6 +24,19 @@ public class ZulrahHelperPhasePanel extends JPanel implements MouseListener {
         this.phase = phase;
 
         BufferedImage img = processImg(phase.getImage(plugin.getConfig()), rows);
+        switch (plugin.getConfig().imageOrientation())
+        {
+            case RIGHT:
+                img = ImageUtil.rotateImage(img, Math.PI / 2);
+                break;
+            case UPSIDE_DOWN:
+                img = ImageUtil.rotateImage(img, Math.PI);
+                break;
+            case LEFT:
+                img = ImageUtil.rotateImage(img, Math.PI * 1.5f);
+                break;
+        }
+
         phaseIcon = new ImageIcon(img);
         phaseIconHover = new ImageIcon(ImageUtil.luminanceScale(img, .75f));
 


### PR DESCRIPTION
This pull request implements a new feature that allows players to rotate the Zulrah phase images to a desired orientation.
Some players are used to rotating the camera in-game to a specific angle, which makes the images not match with what they are seeing. This setting should allow them to fix this.
The default behavior is still the same.