### PR TITLE
ttl: return empty string instead of null for rates config

### DIFF
--- a/src/main/java/com/ttl/TimeToLevelConfig.java
+++ b/src/main/java/com/ttl/TimeToLevelConfig.java
@@ -21,7 +21,7 @@ public interface TimeToLevelConfig extends Config {
             description = ""
     )
     default String rates() {
-        return null;
+        return "";
     }
 
 


### PR DESCRIPTION
Closes #7